### PR TITLE
refactor: update clashofclans.js to dev and adapt to breaking changes

### DIFF
--- a/libs/clash-client/src/clash-client.helper.ts
+++ b/libs/clash-client/src/clash-client.helper.ts
@@ -1,7 +1,7 @@
-import { APIClanWarAttack, APIPlayer, RawData } from 'clashofclans.js';
+import { APIClanWarAttack, APIPlayer, RAW_DATA } from 'clashofclans.js';
 import { HOME_TROOPS, SUPER_TROOPS } from './constants';
 
-export const RAW_TROOPS_FILTERED = RawData.RawUnits.filter((unit) => !unit.seasonal)
+export const RAW_TROOPS_FILTERED = RAW_DATA.RAW_UNITS.filter((unit) => !unit.seasonal)
   .filter((unit) => unit.category !== 'equipment')
   .filter((unit) => !SUPER_TROOPS.includes(unit.name))
   .filter((unit) => HOME_TROOPS.includes(unit.name));

--- a/libs/clash-client/src/client.ts
+++ b/libs/clash-client/src/client.ts
@@ -68,8 +68,6 @@ export class ClashClient extends RESTManager {
       rejectIfNotValid: false,
       restRequestTimeout: 10_000,
       retryLimit: 0,
-      connections: 50,
-      pipelining: 10,
       baseURL,
       keys,
       throttler: rateLimit ? new QueueThrottler(rateLimit) : null,

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@sentry/profiling-node": "^10.32.1",
     "bull": "^4.16.5",
     "cache-manager": "^7.2.0",
-    "clashofclans.js": "3.6.1-dev.65db7bc",
+    "clashofclans.js": "3.6.3-dev.f3ad7c0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.2",
     "cookie-parser": "^1.4.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,8 +78,8 @@ importers:
         specifier: ^7.2.0
         version: 7.2.0
       clashofclans.js:
-        specifier: 3.6.1-dev.65db7bc
-        version: 3.6.1-dev.65db7bc
+        specifier: 3.6.3-dev.f3ad7c0
+        version: 3.6.3-dev.f3ad7c0
       class-transformer:
         specifier: ^0.5.1
         version: 0.5.1
@@ -491,10 +491,6 @@ packages:
   '@eslint/plugin-kit@0.3.5':
     resolution: {integrity: sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@fastify/busboy@2.1.1':
-    resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
-    engines: {node: '>=14'}
 
   '@google-cloud/local-auth@2.1.0':
     resolution: {integrity: sha512-ymZ1XuyKcRcro0aiMYz3hVGbZ+QZmN5V1Eyjvw2k1xqq76PwmDer0DIPxdxkLzfW9Inr8+g+MS9t9fZ7dOlTOQ==}
@@ -1558,41 +1554,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -1949,9 +1953,9 @@ packages:
   cjs-module-lexer@2.1.0:
     resolution: {integrity: sha512-UX0OwmYRYQQetfrLEZeewIFFI+wSTofC+pMBLNuH3RUuu/xzG1oz84UCEDOSoQlN3fZ4+AzmV50ZYvGqkMh9yA==}
 
-  clashofclans.js@3.6.1-dev.65db7bc:
-    resolution: {integrity: sha512-jbvRkghkThZFColNWjS13yATzSDWWB2NkjkKMjvLLCeG0cHsWeofUlJoGV7fJhG/uNO0I6YWzo+hZoDM6AHouA==}
-    engines: {node: '>=18.x'}
+  clashofclans.js@3.6.3-dev.f3ad7c0:
+    resolution: {integrity: sha512-a/G5SaUBonU/MXnDlnh4MH4LFz23Wcv78L/e5MI86DDwoRZNupGPL62KzLcC9HlrY4WI2pfKrvgbdQbK35Gsew==}
+    engines: {bun: '>=1.0.0', node: '>=20.x'}
 
   class-transformer@0.5.1:
     resolution: {integrity: sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==}
@@ -3985,10 +3989,6 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
-  undici@5.29.0:
-    resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
-    engines: {node: '>=14.0'}
-
   undici@6.21.3:
     resolution: {integrity: sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==}
     engines: {node: '>=18.17'}
@@ -4486,8 +4486,6 @@ snapshots:
     dependencies:
       '@eslint/core': 0.15.2
       levn: 0.4.1
-
-  '@fastify/busboy@2.1.1': {}
 
   '@google-cloud/local-auth@2.1.0':
     dependencies:
@@ -6237,9 +6235,7 @@ snapshots:
 
   cjs-module-lexer@2.1.0: {}
 
-  clashofclans.js@3.6.1-dev.65db7bc:
-    dependencies:
-      undici: 5.29.0
+  clashofclans.js@3.6.3-dev.f3ad7c0: {}
 
   class-transformer@0.5.1: {}
 
@@ -8438,10 +8434,6 @@ snapshots:
   uint8array-extras@1.4.1: {}
 
   undici-types@6.21.0: {}
-
-  undici@5.29.0:
-    dependencies:
-      '@fastify/busboy': 2.1.1
 
   undici@6.21.3: {}
 


### PR DESCRIPTION
- Rename RawData.RawUnits to RAW_DATA.RAW_UNITS (UPPER_SNAKE_CASE)
- Remove deprecated connections/pipelining options (undici removed)
- Upgrade clashofclans.js to 3.6.3-dev.f3ad7c0

https://claude.ai/code/session_01RoU9FU9c1weowbSS6CAHLN